### PR TITLE
Allow `$` and `+` in emote names

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -19,7 +19,7 @@ export namespace Constants {
 			LIVE = 3
 		}
 
-		export const NAME_REGEXP = new RegExp(/^[A-Za-z_\-\(\)\:0-9]{2,100}$/);
+		export const NAME_REGEXP = new RegExp(/^[A-Za-z_\-\(\)\$+:0-9]{2,100}$/);
 		export const MAX_EMOTE_LENGTH = 100;
 		export const MIN_EMOTE_LENGTH = 2;
 		export const NAME_PATTERN_ERROR = ''.concat(


### PR DESCRIPTION
- Goes with https://github.com/SevenTV/ServerGo/pull/227